### PR TITLE
Feature: More customizable pointer events for advanced use cases

### DIFF
--- a/src/Viewport.ts
+++ b/src/Viewport.ts
@@ -1,5 +1,5 @@
 import { Container, DestroyOptions, EventSystem, IHitArea, Point, PointData, Rectangle, Ticker, View } from 'pixi.js';
-import { InputManager } from './InputManager';
+import { InputManager, type ICustomPointerConfig } from './InputManager';
 import { PluginManager } from './PluginManager';
 import {
     Animate, Bounce, Clamp, ClampZoom, Decelerate, Drag, Follow, IAnimateOptions,
@@ -55,7 +55,6 @@ export interface IViewportOptions
     /**
      * Whether to stop drag when the pointer is out of the viewport
      */
-
     allowPreserveDragOutside?:boolean;
 
     /**
@@ -86,6 +85,12 @@ export interface IViewportOptions
      * @default PIXI.Ticker.shared
      */
     ticker?: Ticker;
+
+    /**
+     * Give you more control over which event listeners will be added.
+     * Configure only if you fully understand "InputManager.addCustomPointerListeners".
+     */
+    customPointerConfig?: ICustomPointerConfig;
 }
 
 export interface ICompleteViewportOptions extends IViewportOptions
@@ -208,6 +213,8 @@ export class Viewport extends Container
      * @param {PIXI.EventSystem} [options.events] EventSystem available from app.events or added manually and passed here
      * location on screen
      * @param {boolean} [options.disableOnContextMenu] remove oncontextmenu=() => {} from the pixi's events.domElement
+     * @param {ICustomPointerConfig} [options.customPointerConfig] Give you more control over which event listeners will be added.
+     * Configure only if you fully understand "InputManager.addCustomPointerListeners".
      */
     constructor(options: IViewportOptions)
     {


### PR DESCRIPTION
It's always been hard if there are interactive childs inside Viewport containers.
Devs have to be careful with all those event bubbling and capturing stuff to make things work as they expect.

Recently, I was adding a few childs with 'pointertap' events into Viewport, hoping the child events would be emitted before Viewport events. Then I found out 'pointertap' event was not added by InputManager, therefore event bubbling didn't work.

This makes me think if it's a good idea to provide additional options for devs to fully control Viewport's pointer events. I believe it might be useful in some rare use cases.

This commit adds a new property to IViewportOption. People won't notice any difference if this prop is not specified.